### PR TITLE
change eq selector within setSlideClasses

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2328,7 +2328,7 @@
                 if (index === 0) {
 
                     allSlides
-                        .eq(0)
+                        .eq(allSlides.length - 1 - _.options.slidesToShow - (_.slideCount - 1 - _.options.slidesToShow))
                         .addClass('slick-center');
 
                 } else if (index === _.slideCount - 1) {


### PR DESCRIPTION
when the index is 0, the slide finder query does not find the correct clone to target for adding slick-center class